### PR TITLE
Avoid running blocking operations in an async context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 logging = []
 
 [dependencies]
+async-trait = "0.1.52"
 tokio = {version = "1", features = ["full"]}
 log = "0.4.14"
 

--- a/examples/reciever.rs
+++ b/examples/reciever.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use tokio::fs::File;
 
 use dovepipe::{reciever::ProgressTracking, recv_file, Source};
 
@@ -9,7 +9,7 @@ async fn main() {
 
     recv_file(
         Source::Port(port),
-        &mut File::create("output_from_recv.txt").expect("could not create output file"),
+        &mut File::create("output_from_recv.txt").await.expect("could not create output file"),
         "127.0.0.1:3456",
         ProgressTracking::Memory,
     )

--- a/examples/reciever.rs
+++ b/examples/reciever.rs
@@ -9,7 +9,9 @@ async fn main() {
 
     recv_file(
         Source::Port(port),
-        &mut File::create("output_from_recv.txt").await.expect("could not create output file"),
+        &mut File::create("output_from_recv.txt")
+            .await
+            .expect("could not create output file"),
         "127.0.0.1:3456",
         ProgressTracking::Memory,
     )

--- a/examples/reciever_addr_input.rs
+++ b/examples/reciever_addr_input.rs
@@ -1,4 +1,5 @@
-use std::{fs::File, io, net::SocketAddr, str::FromStr};
+use std::{io, net::SocketAddr, str::FromStr};
+use tokio::fs::File;
 
 use dovepipe::{reciever::ProgressTracking, recv_file, Source};
 
@@ -18,7 +19,7 @@ async fn main() {
 
     recv_file(
         Source::Port(7890),
-        &mut File::create("output_from_recv.txt").expect("could not create output file"),
+        &mut File::create("output_from_recv.txt").await.expect("could not create output file"),
         reciever,
         ProgressTracking::Memory,
     )

--- a/examples/reciever_addr_input.rs
+++ b/examples/reciever_addr_input.rs
@@ -19,7 +19,9 @@ async fn main() {
 
     recv_file(
         Source::Port(7890),
-        &mut File::create("output_from_recv.txt").await.expect("could not create output file"),
+        &mut File::create("output_from_recv.txt")
+            .await
+            .expect("could not create output file"),
         reciever,
         ProgressTracking::Memory,
     )

--- a/examples/sender.rs
+++ b/examples/sender.rs
@@ -1,4 +1,4 @@
-use dovepipe::{Source, send_file};
+use dovepipe::{send_file, Source};
 
 #[tokio::main]
 async fn main() {

--- a/examples/sender_addr_input.rs
+++ b/examples/sender_addr_input.rs
@@ -1,6 +1,6 @@
 use std::{io, net::SocketAddr, str::FromStr};
 
-use dovepipe::{Source, send_file};
+use dovepipe::{send_file, Source};
 
 #[tokio::main]
 async fn main() {

--- a/src/reciever.rs
+++ b/src/reciever.rs
@@ -1,14 +1,18 @@
+use async_trait::async_trait;
 #[cfg(feature = "logging")]
 use log::debug;
 #[cfg(feature = "logging")]
 use log::info;
-use async_trait::async_trait;
 use std::{
     error,
     io::{self},
     time::Duration,
 };
-use tokio::{net::ToSocketAddrs, time, fs::{remove_file, File, OpenOptions}};
+use tokio::{
+    fs::{remove_file, File, OpenOptions},
+    net::ToSocketAddrs,
+    time,
+};
 
 use crate::{read_position, recv, send_unil_recv, u8s_to_u64, write_position, Source};
 
@@ -297,9 +301,9 @@ async fn write_msg(
 }
 
 /// # This is used to recieve files
-/// 
+///
 /// ## Sending example
-/// 
+///
 /// This is taken from the official examples
 /// ```
 /// let port = 7890;
@@ -314,12 +318,12 @@ async fn write_msg(
 /// .await
 /// .expect("error when sending file");
 /// ```
-/// This takes in a source which is the UdpSocket to send recieve from. 
-/// 
+/// This takes in a source which is the UdpSocket to send recieve from.
+///
 /// This looks for any senders on port 7890 on ip 127.0.0.1.
 /// *Note: 127.0.0.1 is the same as localhost*
-/// 
-/// When it finds one it will send the file 
+///
+/// When it finds one it will send the file
 ///
 pub async fn recv_file<T>(
     source: Source,
@@ -380,7 +384,9 @@ where
     // Create index file
     // TODO Check so that file doesn't already exist
     let mut prog_tracker: Box<dyn ProgressTracker> = match progress_tracking {
-        ProgressTracking::File(filename) => Box::new(FileProgTrack::new(filename, size).await.unwrap()),
+        ProgressTracking::File(filename) => {
+            Box::new(FileProgTrack::new(filename, size).await.unwrap())
+        }
         ProgressTracking::Memory => Box::new(MemProgTracker::new(size)),
     };
 
@@ -478,7 +484,7 @@ where
             let msg_num = write_msg(buf, file, &mut prog_tracker)?;
             #[cfg(not(feature = "logging"))]
             write_msg(buf, file, &mut prog_tracker).await?;
-            
+
             #[cfg(feature = "logging")]
             info!("msg {} / {}, {}%", msg_num, size, msg_num * 100 / size);
             first = false;

--- a/src/reciever.rs
+++ b/src/reciever.rs
@@ -2,20 +2,21 @@
 use log::debug;
 #[cfg(feature = "logging")]
 use log::info;
+use async_trait::async_trait;
 use std::{
     error,
-    fs::{remove_file, File, OpenOptions},
     io::{self},
     time::Duration,
 };
-use tokio::{net::ToSocketAddrs, time};
+use tokio::{net::ToSocketAddrs, time, fs::{remove_file, File, OpenOptions}};
 
 use crate::{read_position, recv, send_unil_recv, u8s_to_u64, write_position, Source};
 
+#[async_trait]
 trait ProgressTracker {
-    fn recv_msg(&mut self, msg_num: u64) -> Result<(), Box<dyn error::Error>>;
-    fn get_unrecv(&self) -> Result<Vec<u64>, Box<dyn error::Error>>;
-    fn destruct(&self);
+    async fn recv_msg(&mut self, msg_num: u64) -> Result<(), Box<dyn error::Error + Send + Sync>>;
+    async fn get_unrecv(&self) -> Result<Vec<u64>, Box<dyn error::Error + Send + Sync>>;
+    async fn destruct(&self);
 }
 
 struct FileProgTrack {
@@ -25,15 +26,16 @@ struct FileProgTrack {
 }
 
 impl FileProgTrack {
-    fn new(filename: String, size: u64) -> Result<Self, Box<dyn error::Error>> {
+    async fn new(filename: String, size: u64) -> Result<Self, Box<dyn error::Error>> {
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .open(&filename)?;
+            .open(&filename)
+            .await?;
 
         // Populate file with 0:s
-        file.set_len(get_msg_amt(size))?;
+        file.set_len(get_msg_amt(size)).await?;
 
         Ok(Self {
             filename,
@@ -43,14 +45,14 @@ impl FileProgTrack {
     }
 }
 
+#[async_trait]
 impl ProgressTracker for FileProgTrack {
-    fn recv_msg(&mut self, msg_num: u64) -> Result<(), Box<dyn error::Error>> {
+    async fn recv_msg(&mut self, msg_num: u64) -> Result<(), Box<dyn error::Error + Send + Sync>> {
         // Get position in index file
         let (offset, pos_in_offset) = get_pos_of_num(msg_num);
 
         // Read offset position from index file
-        let mut offset_buf = [0u8; 1];
-        read_position(&self.file, &mut offset_buf, offset)?;
+        let (offset_buf, _) = read_position(&self.file, [0u8; 1], offset).await?;
 
         // Change the offset
         let mut offset_binary = to_binary(offset_buf[0]);
@@ -58,12 +60,12 @@ impl ProgressTracker for FileProgTrack {
         let offset_buf = from_binary(offset_binary);
 
         // Write the offset
-        write_position(&self.file, &[offset_buf], offset)?;
+        write_position(&self.file, [offset_buf], offset).await?;
 
         Ok(())
     }
 
-    fn get_unrecv(&self) -> Result<Vec<u64>, Box<dyn error::Error>> {
+    async fn get_unrecv(&self) -> Result<Vec<u64>, Box<dyn error::Error + Send + Sync>> {
         let mut dropped: Vec<u64> = Vec::new();
 
         // let mut byte = num / 8;
@@ -75,11 +77,10 @@ impl ProgressTracker for FileProgTrack {
             self.size / 500 + 1
         };
 
-        for byte in 0..self.file.metadata()?.len() {
+        for byte in 0..self.file.metadata().await?.len() {
             // For every byte
-            let mut buf = [0u8];
-            read_position(&self.file, &mut buf, byte)?;
-            let bin = to_binary(buf[0]);
+            let ([bin], _) = read_position(&self.file, [0u8], byte).await?;
+            let bin = to_binary(bin);
 
             let mut bit_pos = 0;
             for bit in bin {
@@ -103,8 +104,8 @@ impl ProgressTracker for FileProgTrack {
         Ok(dropped)
     }
 
-    fn destruct(&self) {
-        remove_file(&self.filename).unwrap()
+    async fn destruct(&self) {
+        remove_file(&self.filename).await.unwrap()
     }
 }
 
@@ -128,8 +129,9 @@ impl MemProgTracker {
     }
 }
 
+#[async_trait]
 impl ProgressTracker for MemProgTracker {
-    fn recv_msg(&mut self, msg_num: u64) -> Result<(), Box<dyn error::Error>> {
+    async fn recv_msg(&mut self, msg_num: u64) -> Result<(), Box<dyn error::Error + Send + Sync>> {
         // Get position in index file
         let (offset, pos_in_offset) = get_pos_of_num(msg_num);
 
@@ -146,7 +148,7 @@ impl ProgressTracker for MemProgTracker {
         Ok(())
     }
 
-    fn get_unrecv(&self) -> Result<Vec<u64>, Box<dyn error::Error>> {
+    async fn get_unrecv(&self) -> Result<Vec<u64>, Box<dyn error::Error + Send + Sync>> {
         let mut dropped: Vec<u64> = Vec::new();
 
         // let mut byte = num / 8;
@@ -183,7 +185,7 @@ impl ProgressTracker for MemProgTracker {
         Ok(dropped)
     }
 
-    fn destruct(&self) {}
+    async fn destruct(&self) {}
 }
 
 pub enum ProgressTracking {
@@ -275,21 +277,21 @@ fn from_binary(bin: [bool; 8]) -> u8 {
     num
 }
 
-fn write_msg(
+async fn write_msg(
     buf: &[u8],
     out_file: &File,
     prog_tracker: &mut Box<dyn ProgressTracker>,
-) -> Result<u64, Box<dyn error::Error>> {
+) -> Result<u64, Box<dyn error::Error + Send + Sync>> {
     // Get msg num
     let msg_num = u8s_to_u64(&buf[0..8])?;
 
     let msg_offset = get_offset(msg_num);
 
     // Write the data of the msg to out_file
-    let rest = &buf[8..];
-    write_position(out_file, &rest, msg_offset).unwrap();
+    let rest = buf[8..].to_owned();
+    write_position(out_file, rest, msg_offset).await.unwrap();
 
-    prog_tracker.recv_msg(msg_num)?;
+    prog_tracker.recv_msg(msg_num).await?;
 
     Ok(msg_num)
 }
@@ -324,7 +326,7 @@ pub async fn recv_file<T>(
     file: &mut File,
     sender: T,
     progress_tracking: ProgressTracking,
-) -> Result<(), Box<dyn error::Error>>
+) -> Result<(), Box<dyn error::Error + Send + Sync>>
 where
     T: 'static + Clone + ToSocketAddrs + std::marker::Send + Copy, // This many traits is probalbly unnececery but it works
 {
@@ -378,7 +380,7 @@ where
     // Create index file
     // TODO Check so that file doesn't already exist
     let mut prog_tracker: Box<dyn ProgressTracker> = match progress_tracking {
-        ProgressTracking::File(filename) => Box::new(FileProgTrack::new(filename, size).unwrap()),
+        ProgressTracking::File(filename) => Box::new(FileProgTrack::new(filename, size).await.unwrap()),
         ProgressTracking::Memory => Box::new(MemProgTracker::new(size)),
     };
 
@@ -387,7 +389,7 @@ where
         let mut first_data: Option<([u8; 508], usize)> = None;
 
         if !first {
-            let dropped = prog_tracker.get_unrecv()?;
+            let dropped = prog_tracker.get_unrecv().await?;
 
             if dropped.len() == 0 {
                 // Send message that everything is recieved
@@ -475,7 +477,7 @@ where
             #[cfg(feature = "logging")]
             let msg_num = write_msg(buf, file, &mut prog_tracker)?;
             #[cfg(not(feature = "logging"))]
-            write_msg(buf, file, &mut prog_tracker)?;
+            write_msg(buf, file, &mut prog_tracker).await?;
             
             #[cfg(feature = "logging")]
             info!("msg {} / {}, {}%", msg_num, size, msg_num * 100 / size);
@@ -488,7 +490,7 @@ where
 }
 
 /// Converts an array of dropped messages into a 'dropped messages' message
-fn gen_dropped_msg(dropped: Vec<u64>) -> Result<Vec<u8>, Box<dyn error::Error>> {
+fn gen_dropped_msg(dropped: Vec<u64>) -> Result<Vec<u8>, Box<dyn error::Error + Send + Sync>> {
     if dropped.len() > 63 {
         return Err(Box::new(io::Error::new(
             io::ErrorKind::InvalidInput,

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -4,7 +4,7 @@ use std::{error, time::Duration};
 use log::debug;
 #[cfg(feature = "logging")]
 use log::info;
-use tokio::{net::ToSocketAddrs, time, fs::File};
+use tokio::{fs::File, net::ToSocketAddrs, time};
 
 use crate::{get_buf, punch_hole, read_position, send_unil_recv, u8s_to_u64, Source};
 
@@ -21,12 +21,12 @@ where
 }
 
 /// # This is used to send files
-/// 
+///
 /// ## Example
 /// ```
 /// let port = 3456;
 /// println!("my ip: 127.0.0.1:{}", port);
-/// 
+///
 /// send_file(
 ///     Source::Port(port),
 ///     "./examples/file_to_send.txt",
@@ -35,11 +35,11 @@ where
 /// .await
 /// .expect("error when sending file");
 /// ```
-/// 
+///
 /// This takes in a source which is the udp socket to send from
-/// 
+///
 /// This will listen for any recievers on port 3456 on ip 127.0.0.1. *Note: localhost and 127.0.0.1 are the same.*
-/// 
+///
 pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::fmt::Display>(
     source: Source,
     file_name: &str,
@@ -157,7 +157,7 @@ pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::f
         }
 
         let missed = &buf[1..];
-        
+
         #[cfg(feature = "logging")]
         info!("Dropped messages: {}", missed.len() / 8);
         for i in 0..(missed.len() / 8) {
@@ -166,7 +166,8 @@ pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::f
             let missed_msg = u8s_to_u64(&missed[j..j + 8])?;
 
             // Read from file
-            let (file_buf, amt) = get_file_buf_from_msg_num(missed_msg, &input_file, 500, [0u8; 500]).await?;
+            let (file_buf, amt) =
+                get_file_buf_from_msg_num(missed_msg, &input_file, 500, [0u8; 500]).await?;
             let file_buf = &file_buf[0..amt];
             let buf = get_buf(&missed_msg, file_buf);
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,22 +1,23 @@
-use std::{error, fs::File, thread, time::Duration};
+use std::{error, time::Duration};
 
 #[cfg(feature = "logging")]
 use log::debug;
 #[cfg(feature = "logging")]
 use log::info;
-use tokio::{net::ToSocketAddrs, time};
+use tokio::{net::ToSocketAddrs, time, fs::File};
 
 use crate::{get_buf, punch_hole, read_position, send_unil_recv, u8s_to_u64, Source};
 
-fn get_file_buf_from_msg_num(
+async fn get_file_buf_from_msg_num<Buf>(
     msg: u64,
     file: &File,
     buf_size: u64,
-    buf: &mut [u8],
-) -> Result<usize, Box<dyn error::Error>> {
-    let amt = read_position(&file, buf, msg * buf_size)?;
-
-    Ok(amt)
+    buf: Buf,
+) -> Result<(Buf, usize), Box<dyn error::Error + Send + Sync>>
+where
+    Buf: AsMut<[u8]> + Send + 'static,
+{
+    read_position(&file, buf, msg * buf_size).await
 }
 
 /// # This is used to send files
@@ -43,7 +44,7 @@ pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::f
     source: Source,
     file_name: &str,
     reciever: T,
-) -> Result<(), Box<dyn error::Error>> {
+) -> Result<(), Box<dyn error::Error + Send + Sync>> {
     #[cfg(feature = "logging")]
     debug!("reciever ip: {}", reciever);
 
@@ -65,10 +66,10 @@ pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::f
         }
     });
 
-    thread::sleep(Duration::from_millis(1000));
+    time::sleep(Duration::from_millis(1000)).await;
 
-    let input_file = File::open(file_name)?;
-    let file_len = input_file.metadata()?.len();
+    let input_file = File::open(file_name).await?;
+    let file_len = input_file.metadata().await?.len();
 
     let file_len_arr = file_len.to_be_bytes();
     let msg = [
@@ -122,8 +123,7 @@ pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::f
     let mut msg_num: u64 = 0;
 
     loop {
-        let mut file_buf = [0u8; 500];
-        let amt = read_position(&input_file, &mut file_buf, offset)?;
+        let (file_buf, amt) = read_position(&input_file, [0u8; 500], offset).await?;
 
         let buf = get_buf(&msg_num, &file_buf[0..amt]);
 
@@ -165,9 +165,8 @@ pub async fn send_file<T: Clone + 'static + ToSocketAddrs + Send + Copy + std::f
             // Convert bytes to offset
             let missed_msg = u8s_to_u64(&missed[j..j + 8])?;
 
-            let mut file_buf = [0u8; 500];
             // Read from file
-            let amt = get_file_buf_from_msg_num(missed_msg, &input_file, 500, &mut file_buf)?;
+            let (file_buf, amt) = get_file_buf_from_msg_num(missed_msg, &input_file, 500, [0u8; 500]).await?;
             let file_buf = &file_buf[0..amt];
             let buf = get_buf(&missed_msg, file_buf);
 


### PR DESCRIPTION
For reasons explained in [Alice's excellent article](https://ryhl.io/blog/async-what-is-blocking/) it is bad practice to be using APIs like `std::fs::File` and `std::thread::sleep` from within asynchronous code since they can block the thread which causes subtle bugs.

I had to introduce a mild amount of trickery (and one `unsafe` block 😱) to get `read_at` & co to work within async since Tokio does not support them natively, but it should all work fine.

I also included a secondary commit that just runs `cargo fmt` on the code - I wasn't sure if you wanted it since the codebase doesn't currently seem to be rustfmt'd, so you can always tell me to remove that commit.

Also, I had to make all the errors `+ Send + Sync` because I now have to `Send` them over a thread boundary to get `spawn_blocking` to work. But `dyn Error + Send + Sync` is a much more useful type for the user anyway so I think this is a good change either way.